### PR TITLE
Add kotlin resource url in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@
 - Sangho Youn, [GitHub](https://github.com/angelring127)
 - Sungmin Park, [GitHub](https://github.com/ispark323)
 - Jeonghan Gam, [GitHub](https://github.com/jgam)
+
+> kotlin 공부에 도움되는 Url
+
+- [코틀린 학습 리소스](https://developer.android.com/kotlin/resources?hl=ko)


### PR DESCRIPTION
## 수정 내용
기본적이지만 kotlin을 공부하는데 필요한 리소스 url을 추가 했습니다. 
## 참고
